### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/Workshops/docker/README.md
+++ b/Workshops/docker/README.md
@@ -9,6 +9,11 @@ We can follow this workshop fully through Gitpod's VSCode, **no need to install 
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/KISZ-BB/kisz-mlops-docker/)
 
+## Open this Repository on Codeanywhere
+We can follow this workshop fully through Codeanywhere **no need to install software locally**, but we also provide the instructions for a local installation as an option.
+
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/KISZ-BB/kisz-mlops-docker)
+
 ## Local Installation Guide
 This guide provides instructions for installing and setting up all the tools and environments you need to participate in the workshop.
 Familiarity with opening and using a terminal is required. Here's how you can start a terminal:


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.